### PR TITLE
Add light one-page info site for Bolus Connect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#ffffff" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Informational site for the Bolus Connect app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Bolus Connect</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,29 @@
 .App {
   text-align: center;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+header {
+  padding: 2rem 1rem;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+.section {
+  padding: 4rem 1rem;
+  background-color: #ffffff;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+.section img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin: 1rem 0;
 }
 
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.section p {
+  max-width: 700px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,80 @@
-import logo from './logo.svg';
 import './App.css';
 
 function App() {
+  const sections = [
+    {
+      id: 'home',
+      title: 'Home',
+      description:
+        'Welcome to Bolus Connect, your companion for managing bolus insulin doses.'
+    },
+    {
+      id: 'dashboard',
+      title: 'Dashboard',
+      description:
+        'Quick summary of recent boluses and glucose levels to keep you informed at a glance.'
+    },
+    {
+      id: 'calculator',
+      title: 'Bolus Calculator',
+      description:
+        'Calculate suggested bolus doses based on carb intake and current glucose.'
+    },
+    {
+      id: 'meals',
+      title: 'Meal Planner',
+      description:
+        'Store favorite meals and carb counts for fast entry when it is time to eat.'
+    },
+    {
+      id: 'logbook',
+      title: 'Logbook',
+      description:
+        'Review historical bolus entries and personal notes for better tracking.'
+    },
+    {
+      id: 'reminders',
+      title: 'Reminders',
+      description:
+        'Set notifications so you never miss an important dose or check.'
+    },
+    {
+      id: 'analytics',
+      title: 'Analytics',
+      description:
+        'Visualize trends in insulin usage and glucose response over time.'
+    },
+    {
+      id: 'profile',
+      title: 'Profile',
+      description:
+        'Manage your personal and medical information in one secure place.'
+    },
+    {
+      id: 'settings',
+      title: 'Settings',
+      description:
+        'Customize Bolus Connect to fit your preferences and needs.'
+    }
+  ];
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+      <header>
+        <h1>Bolus Connect</h1>
       </header>
+      {sections.map((section) => (
+        <section key={section.id} id={section.id} className="section">
+          <h2>{section.title}</h2>
+          <img
+            src={`https://via.placeholder.com/600x400?text=${encodeURIComponent(
+              section.title
+            )}`}
+            alt={`${section.title} screenshot`}
+          />
+          <p>{section.description}</p>
+        </section>
+      ))}
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders application title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /bolus connect/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -5,6 +9,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f5;
+  color: #333;
 }
 
 code {


### PR DESCRIPTION
## Summary
- Convert app into a single-scroll informational site with light theme
- Describe nine app sections and include placeholder screenshots
- Update tests and page metadata

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68acb00fd8b8832e8a8ed98e0b024973