### PR TITLE
Allow sections to define custom images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Section Images
+
+Each entry in the `sections` array within `src/App.js` now accepts an `image` field.
+Provide a URL or path to an image for that section to display a custom graphic
+instead of the default placeholder.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.js
+++ b/src/App.js
@@ -6,55 +6,82 @@ function App() {
       id: 'home',
       title: 'Home',
       description:
-        'Welcome to Bolus Connect, your companion for managing bolus insulin doses.'
+        'Welcome to Bolus Connect, your companion for managing bolus insulin doses.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Home')
     },
     {
       id: 'dashboard',
       title: 'Dashboard',
       description:
-        'Quick summary of recent boluses and glucose levels to keep you informed at a glance.'
+        'Quick summary of recent boluses and glucose levels to keep you informed at a glance.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Dashboard')
     },
     {
       id: 'calculator',
       title: 'Bolus Calculator',
       description:
-        'Calculate suggested bolus doses based on carb intake and current glucose.'
+        'Calculate suggested bolus doses based on carb intake and current glucose.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Bolus Calculator')
     },
     {
       id: 'meals',
       title: 'Meal Planner',
       description:
-        'Store favorite meals and carb counts for fast entry when it is time to eat.'
+        'Store favorite meals and carb counts for fast entry when it is time to eat.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Meal Planner')
     },
     {
       id: 'logbook',
       title: 'Logbook',
       description:
-        'Review historical bolus entries and personal notes for better tracking.'
+        'Review historical bolus entries and personal notes for better tracking.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Logbook')
     },
     {
       id: 'reminders',
       title: 'Reminders',
       description:
-        'Set notifications so you never miss an important dose or check.'
+        'Set notifications so you never miss an important dose or check.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Reminders')
     },
     {
       id: 'analytics',
       title: 'Analytics',
       description:
-        'Visualize trends in insulin usage and glucose response over time.'
+        'Visualize trends in insulin usage and glucose response over time.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Analytics')
     },
     {
       id: 'profile',
       title: 'Profile',
       description:
-        'Manage your personal and medical information in one secure place.'
+        'Manage your personal and medical information in one secure place.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Profile')
     },
     {
       id: 'settings',
       title: 'Settings',
       description:
-        'Customize Bolus Connect to fit your preferences and needs.'
+        'Customize Bolus Connect to fit your preferences and needs.',
+      image:
+        'https://via.placeholder.com/600x400?text=' +
+        encodeURIComponent('Settings')
     }
   ];
 
@@ -66,12 +93,7 @@ function App() {
       {sections.map((section) => (
         <section key={section.id} id={section.id} className="section">
           <h2>{section.title}</h2>
-          <img
-            src={`https://via.placeholder.com/600x400?text=${encodeURIComponent(
-              section.title
-            )}`}
-            alt={`${section.title} screenshot`}
-          />
+          <img src={section.image} alt={`${section.title} screenshot`} />
           <p>{section.description}</p>
         </section>
       ))}


### PR DESCRIPTION
## Summary
- add `image` field to each section
- render section images and document usage

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68acb36f5ce4832ebb07e3d1d6bf24e3